### PR TITLE
feat: personalize site content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jg-portfolio",
   "version": "0.1.0",
-  "homepage": "https://joshuagonzales.org/",
+  "homepage": "https://example.com/",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^9.109.2",

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Joshua Gonzales</title>
+    <title>Your Name</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import Confetti from 'react-dom-confetti';
+import profile from '../profile';
 
 function Header() {
   const [showMore, setShowMore] = useState(false);
   const [isExploding, setIsExploding] = React.useState(false);
+  const firstName = profile.fullName.split(' ')[0];
 
   const config = {
     angle: 90,
@@ -33,7 +35,7 @@ function Header() {
   return (
     <header className="">
       <Confetti active={ isExploding } config={ config }/>
-      <h1 className="font-Outfit text-5xl font-bold">{">>"} jg.</h1>
+      <h1 className="font-Outfit text-5xl font-bold">{">>"} {profile.initials}.</h1>
       <p className="font-Inter font-normal mt-6"> <span className="bg-da_green">having fun comes first and great work will follow.</span> Well tbh, still figuring out what that really means, but I'm diving in headfirst</p>
       <p className="font-Inter font-normal mt-6">—and that's what matters.</p>
       <div className={`transition-all duration-500 ${showMore ? 'max-h-[1000px]' : 'max-h-0'} overflow-hidden ${showMore ? '' : 'm-0'}`}>
@@ -43,7 +45,7 @@ function Header() {
             <em>Make it Fun. Make it Cool. Make it Yours.</em>
           </p>
           <p className="mt-4 font-Inter font-normal">
-            Hey this is Josh, welcome! I'm currently a student at Queen's University, Ontario, Canada finishing my Bachelors on Computer and Electrical Engineering with <em>2+ years of professional experience</em>. <strong>I bring a unique blend of technical expertise and passion to pick up literally anything and run with it.</strong> 
+            Hey this is {firstName}, welcome! I'm currently a student at Queen's University, Ontario, Canada finishing my Bachelors on Computer and Electrical Engineering with <em>2+ years of professional experience</em>. <strong>I bring a unique blend of technical expertise and passion to pick up literally anything and run with it.</strong>
           </p>
           <p className="mt-4 font-Inter font-normal">
             You might notice that I choose a little bit of everything in my projects (not even just coding!)
@@ -76,7 +78,7 @@ function Header() {
           className="relative overflow-hidden transition-all bg-white hover:bg-da_green group rounded-md flex items-center justify-center w-[108px] h-[44px] border-current border-2"
           onClick={() => {
             setIsExploding(!isExploding);
-            navigator.clipboard.writeText('joshgonzales9891@gmail.com');
+            navigator.clipboard.writeText(profile.email);
             alert('Email copied to clipboard! :)');
           }}
         >

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -4,6 +4,7 @@ import Menu from './Menu';
 import AudioPlayer from './AudioPlayer';
 import { MusicProvider } from './MusicContext';
 import { FiberContainer } from './FiberContainer';
+import profile from '../profile';
 
 function Main() {  
   return (
@@ -34,7 +35,7 @@ function Main() {
           </div>
         </div>
       <div className="relative z-30 bg-da_green">
-        <p className="uppercase font-DMMono">@Joshua Gonzales</p>
+        <p className="uppercase font-DMMono">@{profile.fullName}</p>
       </div>
       </div>
       <video id="video" className='hidden' loop>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Confetti from 'react-dom-confetti';
+import profile from '../profile';
 
 function Menu({ className }) {
     const [isExploding, setIsExploding] = React.useState(false);
@@ -24,7 +25,7 @@ function Menu({ className }) {
                 <a className="relative overflow-hidden transition-all bg-zinc-100 hover:bg-da_green group flex items-center justify-center cursor-pointer"
                     onClick={() => {
                         setIsExploding(!isExploding);
-                        navigator.clipboard.writeText('joshgonzales9891@gmail.com');
+                        navigator.clipboard.writeText(profile.email);
                         alert('Email copied to clipboard! :)');
                     }}>
                     <span className="absolute top-0 right-0 w-full h-full bg-da_green rounded-md translate-x-full ease-out duration-200 transition-all group-hover:translate-x-0"></span>

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,0 +1,7 @@
+const profile = {
+  fullName: 'Your Name',
+  email: 'your.email@example.com',
+  initials: 'yn'
+};
+
+export default profile;


### PR DESCRIPTION
## Summary
- centralize personal details in `src/profile.js`
- use profile data for header, footer, and email actions
- update page title and homepage to generic placeholders

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot set properties of null (setting 'fillStyle'))*


------
https://chatgpt.com/codex/tasks/task_e_689f89929370832287b6fa60052f2130