### PR TITLE
Use DM Mono font globally with smoother scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply scroll-smooth;
+  }
+  body {
+    @apply font-DMMono tracking-wide;
+  }
+}


### PR DESCRIPTION
## Summary
- Apply DM Mono font site-wide with subtle letter spacing
- Enable smooth scrolling for a more fluid experience

## Testing
- `CI=true npm test --silent` *(fails: This browser does not support ResizeObserver out of the box)*

------
https://chatgpt.com/codex/tasks/task_e_689f923f730c8322963d40bac0c3219d