### PR TITLE
Add animated engineering quote section

### DIFF
--- a/src/components/EngineeringQuote.js
+++ b/src/components/EngineeringQuote.js
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const quotes = [
+  "Engineers like to solve problems. If there are no problems handily available, they will create their own problems.",
+  "The fewer moving parts, the better. Exactly. No truer words were ever spoken in the context of engineering.",
+  "Innovation is the calling card of the future.",
+];
+
+function EngineeringQuote() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % quotes.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="mt-6">
+      <AnimatePresence mode="wait">
+        <motion.p
+          key={index}
+          className="font-DMMono text-sm"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.8 }}
+        >
+          {quotes[index]}
+        </motion.p>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default EngineeringQuote;

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -6,6 +6,7 @@ import Skills from './Skills';
 import CoolStuff from './CoolStuff';
 import WannaPlaySomeTunes from './WannaPlaySomeTunes';
 import Header from './Header';
+import EngineeringQuote from './EngineeringQuote';
 
 function Portfolio({ className }) {
   const [projectExpanded, setProjectExpanded] = useState(false);
@@ -25,6 +26,7 @@ function Portfolio({ className }) {
         
         <div className={`${transitionClasses} ${projectExpanded ? expandedClasses : `${collapsedClasses} ${spacingClasses}`}`}>
           <Header />
+          <EngineeringQuote />
         </div>
         <div className={`${transitionClasses} ${projectExpanded ? expandedClasses : `${collapsedClasses} ${spacingClasses}`}`}>
           <Work />


### PR DESCRIPTION
## Summary
- cycle through rotating engineering quotes with subtle animation
- display the quote block beneath the header for extra flair

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot set properties of null (setting 'fillStyle'))*

------
https://chatgpt.com/codex/tasks/task_e_689f9de3212c832299483e08257e0b25