### PR TITLE
Add animated gear background to portfolio site

### DIFF
--- a/src/components/GearBackground.js
+++ b/src/components/GearBackground.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const Gear = ({ className, size }) => (
+  <span
+    role="img"
+    aria-label="gear"
+    className={`inline-block animate-spin-slow ${className}`}
+    style={{ fontSize: size }}
+  >
+    ⚙️
+  </span>
+);
+
+const GearBackground = () => (
+  <div className="pointer-events-none absolute inset-0 overflow-hidden z-0">
+    <Gear className="text-blue-300 absolute top-10 left-10" size="4rem" />
+    <Gear className="text-sea_blue absolute bottom-10 right-10" size="6rem" />
+  </div>
+);
+
+export default GearBackground;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -5,11 +5,13 @@ import AudioPlayer from './AudioPlayer';
 import { MusicProvider } from './MusicContext';
 import { FiberContainer } from './FiberContainer';
 import profile from '../profile';
+import GearBackground from './GearBackground';
 
 function Main() {  
   return (
     <div className="App">
       <div className="relative min-h-screen selection:bg-sea_blue bg-gradient-to-b from-blue-100 via-sea_blue to-blue-900 overflow-hidden ">
+        <GearBackground />
         <div className="">
           <div className="relative z-10 fade-in-anim">
             <MusicProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ module.exports = {
         colors: {
           'sea_blue':'#38BDF8',
         },
+        animation: {
+          'spin-slow': 'spin 8s linear infinite',
+        },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add animated gear background component
- configure Tailwind slow spin animation
- integrate gear background into main layout

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*

------
https://chatgpt.com/codex/tasks/task_e_689f9de3212c832299483e08257e0b25