### PR TITLE
Rework hero section with typed engineering quotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,9 @@
       "devDependencies": {
         "autoprefixer": "^10.4.19",
         "gh-pages": "^6.1.1",
+        "jest-canvas-mock": "^2.5.2",
         "postcss": "^8.4.40",
+        "resize-observer-polyfill": "^1.5.1",
         "tailwindcss": "^3.4.7"
       }
     },
@@ -8009,6 +8011,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssnano": {
       "version": "5.1.15",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
@@ -12345,6 +12354,17 @@
         }
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
@@ -15225,6 +15245,23 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -18258,6 +18295,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
   "devDependencies": {
     "autoprefixer": "^10.4.19",
     "gh-pages": "^6.1.1",
+    "jest-canvas-mock": "^2.5.2",
     "postcss": "^8.4.40",
+    "resize-observer-polyfill": "^1.5.1",
     "tailwindcss": "^3.4.7"
   }
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders portfolio header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/Email Me/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/components/EngineeringQuote.js
+++ b/src/components/EngineeringQuote.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+
+const quotes = [
+  'Engineers like to solve problems. If there are no problems handily available, they will create their own problems.',
+  'The fewer moving parts, the better. Exactly. No truer words were ever spoken in the context of engineering.',
+  'Innovation is the calling card of the future.',
+];
+
+function EngineeringQuote() {
+  const [quoteIndex, setQuoteIndex] = useState(0);
+  const [displayed, setDisplayed] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    const current = quotes[quoteIndex];
+    let timeout;
+    if (isDeleting) {
+      timeout = setTimeout(() => {
+        setDisplayed((prev) => prev.slice(0, -1));
+        if (displayed === '') {
+          setIsDeleting(false);
+          setQuoteIndex((quoteIndex + 1) % quotes.length);
+        }
+      }, 50);
+    } else {
+      timeout = setTimeout(() => {
+        setDisplayed(current.slice(0, displayed.length + 1));
+        if (displayed === current) {
+          timeout = setTimeout(() => setIsDeleting(true), 2000);
+        }
+      }, 100);
+    }
+    return () => clearTimeout(timeout);
+  }, [displayed, isDeleting, quoteIndex]);
+
+  return (
+    <p className="font-DMMono text-sm min-h-[24px]">
+      {displayed}
+      <span className="border-r-2 border-white animate-pulse ml-1" />
+    </p>
+  );
+}
+
+export default EngineeringQuote;

--- a/src/components/HeroSection.js
+++ b/src/components/HeroSection.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from './Header';
+import EngineeringQuote from './EngineeringQuote';
+
+function HeroSection() {
+  return (
+    <section className="flex flex-col items-center justify-center text-center min-h-screen py-16 bg-gradient-to-b from-gray-900 to-gray-800 text-white">
+      <Header />
+      <div className="mt-8">
+        <EngineeringQuote />
+      </div>
+    </section>
+  );
+}
+
+export default HeroSection;

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -1,11 +1,9 @@
 import { useState } from 'react';
 import Work from './Work';
 import Projects from './Projects';
-import ExtendedProjects from './ExtendedProjects';
 import Skills from './Skills';
-import CoolStuff from './CoolStuff';
 import WannaPlaySomeTunes from './WannaPlaySomeTunes';
-import Header from './Header';
+import HeroSection from './HeroSection';
 
 function Portfolio({ className }) {
   const [projectExpanded, setProjectExpanded] = useState(false);
@@ -22,9 +20,9 @@ function Portfolio({ className }) {
   return (
     <main className={`${className} /* other classes */`}>
       <div className="portfolio">
-        
+
         <div className={`${transitionClasses} ${projectExpanded ? expandedClasses : `${collapsedClasses} ${spacingClasses}`}`}>
-          <Header />
+          <HeroSection />
         </div>
         <div className={`${transitionClasses} ${projectExpanded ? expandedClasses : `${collapsedClasses} ${spacingClasses}`}`}>
           <Work />

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,9 @@
+import 'jest-canvas-mock';
+import ResizeObserver from 'resize-observer-polyfill';
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+global.ResizeObserver = ResizeObserver;


### PR DESCRIPTION
## Summary
- create a dedicated hero section combining the existing header with a rotating engineering quote
- overhaul quote component with a typewriter effect and integrate it into the new layout
- add canvas and ResizeObserver polyfills so Jest tests run in this environment

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689f9de3212c832299483e08257e0b25